### PR TITLE
New classes: Closed, Costrong and Cochoice

### DIFF
--- a/docs/Data/Profunctor/Closed.md
+++ b/docs/Data/Profunctor/Closed.md
@@ -1,0 +1,17 @@
+## Module Data.Profunctor.Closed
+
+#### `Closed`
+
+``` purescript
+class (Profunctor p) <= Closed p where
+  closed :: forall a b x. p a b -> p (x -> a) (x -> b)
+```
+
+The `Closed` class extends the `Profunctor` class to work with functions.
+
+##### Instances
+``` purescript
+instance closedFunction :: Closed Function
+```
+
+

--- a/docs/Data/Profunctor/Cochoice.md
+++ b/docs/Data/Profunctor/Cochoice.md
@@ -1,0 +1,13 @@
+## Module Data.Profunctor.Cochoice
+
+#### `Cochoice`
+
+``` purescript
+class (Profunctor p) <= Cochoice p where
+  unleft :: forall a b c. p (Either a c) (Either b c) -> p a b
+  unright :: forall a b c. p (Either a b) (Either a c) -> p b c
+```
+
+The `Cochoice` class provides the dual operations of the `Choice` class.
+
+

--- a/docs/Data/Profunctor/Costrong.md
+++ b/docs/Data/Profunctor/Costrong.md
@@ -1,0 +1,13 @@
+## Module Data.Profunctor.Costrong
+
+#### `Costrong`
+
+``` purescript
+class (Profunctor p) <= Costrong p where
+  unfirst :: forall a b c. p (Tuple a c) (Tuple b c) -> p a b
+  unsecond :: forall a b c. p (Tuple a b) (Tuple a c) -> p b c
+```
+
+The `Costrong` class provides the dual operations of the `Strong` class.
+
+

--- a/src/Data/Profunctor/Closed.purs
+++ b/src/Data/Profunctor/Closed.purs
@@ -1,0 +1,12 @@
+module Data.Profunctor.Closed where
+
+import Prelude
+
+import Data.Profunctor
+
+-- | The `Closed` class extends the `Profunctor` class to work with functions.
+class (Profunctor p) <= Closed p where
+  closed :: forall a b x. p a b -> p (x -> a) (x -> b)
+
+instance Closed Function where
+  closed = (<<<)

--- a/src/Data/Profunctor/Closed.purs
+++ b/src/Data/Profunctor/Closed.purs
@@ -8,5 +8,5 @@ import Data.Profunctor
 class (Profunctor p) <= Closed p where
   closed :: forall a b x. p a b -> p (x -> a) (x -> b)
 
-instance Closed Function where
+instance closedFunction :: Closed Function where
   closed = (<<<)

--- a/src/Data/Profunctor/Cochoice.purs
+++ b/src/Data/Profunctor/Cochoice.purs
@@ -1,0 +1,11 @@
+module Data.Profunctor.Cochoice where
+
+import Prelude
+
+import Data.Either (Either ())
+import Data.Profunctor
+
+-- | The `Cochoice` class provides the dual operations of the `Choice` class.
+class (Profunctor p) <= Cochoice p where
+  unleft :: forall a b c. p (Either a c) (Either b c) -> p a b
+  unright :: forall a b c. p (Either a b) (Either a c) -> p b c

--- a/src/Data/Profunctor/Costrong.purs
+++ b/src/Data/Profunctor/Costrong.purs
@@ -1,8 +1,8 @@
-module Data.Profunctor.Cochoice where
+module Data.Profunctor.Costrong where
 
 import Prelude
 
-import Data.Either (Tuple ())
+import Data.Tuple (Tuple ())
 import Data.Profunctor
 
 -- | The `Costrong` class provides the dual operations of the `Strong` class.

--- a/src/Data/Profunctor/Costrong.purs
+++ b/src/Data/Profunctor/Costrong.purs
@@ -1,0 +1,11 @@
+module Data.Profunctor.Cochoice where
+
+import Prelude
+
+import Data.Either (Tuple ())
+import Data.Profunctor
+
+-- | The `Costrong` class provides the dual operations of the `Strong` class.
+class (Profunctor p) <= Costrong p where
+  unfirst :: forall a b c. p (Tuple a c) (Tuple b c) -> p a b
+  unsecond :: forall a b c. p (Tuple a b) (Tuple a c) -> p b c


### PR DESCRIPTION
There are three types of profunctors this library has been missing out on, which can be quite useful in the profunctor-lens library:

`Closed` is used for implementing `Grate`s (http://r6research.livejournal.com/28050.html), which are an optic generalizing zipping of representable functors. `Costrong` and `Cochoice` can be used to implement a function `re` that not only reverses `Iso`s, but is also able to e.g. reverse a `Prism` to a `Getter`.

Since purescript is not lazy, the instances for `Cochoice` and `Costrong` found in the Haskell analog of this library unfortunately can not work. `Forget` and `Tagged`, however, are instances of `Cochoice` and `Costrong`, respectively. Maybe we should add them, too; with a more descriptive name perhaps?
