### PR TITLE
Add Open Profunctor class

### DIFF
--- a/src/Data/Profunctor/Closed.purs
+++ b/src/Data/Profunctor/Closed.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Data.Profunctor (class Profunctor)
 
--- | The `Closed` class extends the `Profunctor` class to work with functions.
+-- | The `Closed` class extends the `Profunctor` class to work with function codomains.
 class Profunctor p <= Closed p where
   closed :: forall a b x. p a b -> p (x -> a) (x -> b)
 

--- a/src/Data/Profunctor/Open.purs
+++ b/src/Data/Profunctor/Open.purs
@@ -1,0 +1,12 @@
+module Data.Profunctor.Open where
+
+import Prelude
+
+import Data.Profunctor (class Profunctor)
+
+-- | The `Open` class extends the `Profunctor` class to work with function domains.
+class Profunctor p <= Open p where
+  open :: forall a b x. p a b -> p (b -> x) (a -> x)
+
+instance openFunction :: Open Function where
+  open = (>>>)

--- a/src/Data/Profunctor/Star.purs
+++ b/src/Data/Profunctor/Star.purs
@@ -15,6 +15,7 @@ import Data.Newtype (class Newtype)
 import Data.Profunctor (class Profunctor)
 import Data.Profunctor.Choice (class Choice)
 import Data.Profunctor.Closed (class Closed)
+import Data.Profunctor.Open (class Open)
 import Data.Profunctor.Strong (class Strong)
 import Data.Tuple (Tuple(..))
 
@@ -77,3 +78,7 @@ instance choiceStar :: Applicative f => Choice (Star f) where
 
 instance closedStar :: Distributive f => Closed (Star f) where
   closed (Star f) = Star \g -> distribute (f <<< g)
+
+instance openStar :: Distributive f => Open (Star f) where
+  open (Star f) = Star \g -> (g <<< _) <$> distribute f
+


### PR DESCRIPTION
- modify Closed description
- add Open Star instance

Not sure what the best way to write `Open Costar` is, I've done it with `Comonad f => Open (Costar f)`.  But I need to make sure it's correct (later PR).

In the mean time, I'd like to have `Open` so I can do cool things with optics into function arguments:

``` purescript
eg1 = set arg1 "!!!"    (<>) "hello" "world" -- "!!!world"
eg2 = set arg2 "!!!"    (<>) "hello" "world" -- "hello!!!"
eg3 = set out2 "!!!"    (<>) "hello" "world" -- "!!!"
eg4 = over arg1 toUpper (<>) "hello" "world" -- "HELLOworld"
eg5 = over arg2 toUpper (<>) "hello" "world" -- "helloWORLD"
eg6 = over out2 toUpper (<>) "hello" "world" -- "HELLOWORLD"
```
