### PR TITLE
Add Cochoice instances for Joker and Star

### DIFF
--- a/src/Data/Profunctor/Joker.purs
+++ b/src/Data/Profunctor/Joker.purs
@@ -2,10 +2,13 @@ module Data.Profunctor.Joker where
 
 import Prelude
 
-import Data.Either (Either(..))
+import Control.Alternative (empty)
+import Control.MonadPlus (class MonadZero)
+import Data.Either (Either(..), either)
 import Data.Newtype (class Newtype, un)
 import Data.Profunctor (class Profunctor)
 import Data.Profunctor.Choice (class Choice)
+import Data.Profunctor.Cochoice (class Cochoice)
 
 -- | Makes a trivial `Profunctor` for a covariant `Functor`.
 newtype Joker f a b = Joker (f b)
@@ -37,6 +40,11 @@ instance bindJoker :: Bind f => Bind (Joker f a) where
   bind (Joker ma) amb = Joker $ ma >>= (amb >>> un Joker)
 
 instance monadJoker :: Monad m => Monad (Joker m a)
+
+instance cochoiceJoker :: MonadZero f => Cochoice (Joker f)
+  where
+  unleft  (Joker fa) = Joker $ fa >>= either pure (const empty)
+  unright (Joker fb) = Joker $ fb >>= either (const empty) pure
 
 hoistJoker :: forall f g a b. (f ~> g) -> Joker f a b -> Joker g a b
 hoistJoker f (Joker a) = Joker (f a)

--- a/src/Data/Profunctor/Star.purs
+++ b/src/Data/Profunctor/Star.purs
@@ -15,6 +15,7 @@ import Data.Newtype (class Newtype)
 import Data.Profunctor (class Profunctor)
 import Data.Profunctor.Choice (class Choice)
 import Data.Profunctor.Closed (class Closed)
+import Data.Profunctor.Cochoice (class Cochoice)
 import Data.Profunctor.Strong (class Strong)
 import Data.Tuple (Tuple(..))
 
@@ -74,6 +75,10 @@ instance strongStar :: Functor f => Strong (Star f) where
 instance choiceStar :: Applicative f => Choice (Star f) where
   left  (Star f) = Star $ either (map Left <<< f) (pure <<< Right)
   right (Star f) = Star $ either (pure <<< Left) (map Right <<< f)
+
+instance cochoiceStar :: MonadZero f => Cochoice (Star f) where
+  unleft  (Star f) = Star $ \a -> (=<<) (either pure (const empty)) $ f (Left a)
+  unright (Star f) = Star $ \a -> (=<<) (either (const empty) pure) $ f (Right a)
 
 instance closedStar :: Distributive f => Closed (Star f) where
   closed (Star f) = Star \g -> distribute (f <<< g)


### PR DESCRIPTION
These should help with the long standing problem of how to make "failable"
optics. If your profunctor supports a `Cochoice` instance, you can simply
apply a Prism backwards to it.

This lets you "demote" e.g. a:

```purescript
f :: MonadPlus m => Star m (Either a String) (Either a String)
```

to a:

```purescript
f' :: MonadPlus m => Star m String String
f' = re _Right f
```

by running the `_Right` prism backwards.